### PR TITLE
fix: `!uv__is_closing(handle)' failed when quit vim

### DIFF
--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -111,7 +111,7 @@ end
 
 local function change_im_select(cmd, method)
     if cmd:find("fcitx5-remote", 1, true) then
-        return vim.fn.system({ cmd, "-s", method })
+        return vim.fn.jobstart({ cmd, "-s", method }, { detach = true })
     elseif cmd:find("fcitx-remote", 1, true) then
         -- limited support for fcitx, can only switch for inactive and active
         if method == "1" then
@@ -119,9 +119,9 @@ local function change_im_select(cmd, method)
         else
             method = "-o"
         end
-        return vim.fn.system({ cmd, method })
+        return vim.fn.jobstart({ cmd, method }, { detach = true })
     else
-        return vim.fn.system({ cmd, method })
+        return vim.fn.jobstart({ cmd, method }, { detach = true })
     end
 end
 

--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -165,14 +165,14 @@ M.setup = function(opts)
 
     if #C.set_previous_events > 0 then
         vim.api.nvim_create_autocmd(C.set_previous_events, {
-            callback = restore_previous_im,
+            callback = vim.schedule_wrap(restore_previous_im),
             group = group_id,
         })
     end
 
     if #C.set_default_events > 0 then
         vim.api.nvim_create_autocmd(C.set_default_events, {
-            callback = restore_default_im,
+            callback = vim.schedule_wrap(restore_default_im),
             group = group_id,
         })
     end

--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -165,14 +165,14 @@ M.setup = function(opts)
 
     if #C.set_previous_events > 0 then
         vim.api.nvim_create_autocmd(C.set_previous_events, {
-            callback = vim.schedule_wrap(restore_previous_im),
+            callback = restore_previous_im,
             group = group_id,
         })
     end
 
     if #C.set_default_events > 0 then
         vim.api.nvim_create_autocmd(C.set_default_events, {
-            callback = vim.schedule_wrap(restore_default_im),
+            callback = restore_default_im,
             group = group_id,
         })
     end


### PR DESCRIPTION
I'm noticing we use `vim.fn.system` to change input method. This function of neovim is blocked (synchronous) since it wait to get outputs from command. So whenever I exit vim `:q`, I get error like this:

```
neovim: src/unix/core.c:116: uv_close: Assertion `!uv__is_closing(handle)' failed
```

Quick fix is to replace `vim.fn.system` to `vim.fn.jobstart` since we don't actually need `fcitx5-remote -s keyboard-us` output.
Or just wrap whole function with `vim.schedule_wrap` :P