### PR TITLE
fix: fix jobstart cannot execute problem in Windows

### DIFF
--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -137,7 +137,7 @@ local function change_im_select(cmd, method)
     else
         command = { cmd, method }
     end
-    return vim.fn.jobstart(table.concat(command, " "), { detach = true })
+    return vim.fn.jobstart(table.concat(command, " "))
 end
 
 local function restore_default_im()


### PR DESCRIPTION
When `detach`, a `jobstart` opts, is set true, some strange things happens. The jobstart function could not start new process properly.

Although this issue is probably caused by neovim bugs, removing the `detach` option just works.

---
My environment:
- OS Info:
  machine = "x86_64",
  release = "10.0.22621",
  sysname = "Windows_NT",
  version = "Windows 11 Home China"
- Neovim Info:
  NVIM v0.9.1
  Build type: RelWithDebInfo
  LuaJIT 2.1.0-beta3
  Compilation: C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe /MD /Zi /O2 /Ob1  -W3 -wd4311 -wd4146 -DUNIT_TESTING -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -D_WIN32_WINNT=0x0602 -DMSWIN -DINCLUDE_GENERATED_DECLARATIONS -ID:/a/neovim/neovim/.deps/usr/include/luajit-2.1 -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/build/src/nvim/auto -ID:/a/neovim/neovim/build/include -ID:/a/neovim/neovim/build/cmake.config -ID:/a/neovim/neovim/src -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include -ID:/a/neovim/neovim/.deps/usr/include
- Config: lunarvim `release-1.3/neovim-0.9-d1c1bac`
- User config: https://github.com/jxlpzqc/LunarVimConfig


