### PR TITLE
feat: include the ModeChanged event for more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,19 @@ Options with its default values
             default_command = 'im-select.exe',
 
             -- Restore the default input method state when the following events are triggered
-            set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+            set_default_events = { "VimEnter", "FocusGained", ModeChanged = {"i:*", "c:*", "R:*"} },
+
+            -- Save the current input method state when the following ModeChanged patterns are matched
+            save_state_patterns = {"i:n", "R:n"},
 
             -- Restore the previous used input method state when the following events
             -- are triggered, if you don't want to restore previous used im in Insert mode,
             -- e.g. deprecated `disable_auto_restore = 1`, just let it empty
             -- as `set_previous_events = {}`
-            set_previous_events = { "InsertEnter" },
+            set_previous_events = { ModeChanged = {"*:i", "*:R"} },
+
+            -- Don't change the input method state when the following ModeChanged patterns are matched
+            exclude_patterns = {"i:c", "c:i"},
 
             -- Show notification about how to install executable binary when binary missed
             keep_quiet_on_no_binary = false,
@@ -196,6 +202,8 @@ Options with its default values
     end,
 }
 ```
+
+The docs for ModeChanged patterns can be found at [ModeChanged](https://neovim.io/doc/user/autocmd.html#ModeChanged) and [mode()](https://neovim.io/doc/user/builtin.html#mode()).
 
 ## 3. Current Issue
 

--- a/README.md
+++ b/README.md
@@ -179,19 +179,16 @@ Options with its default values
             default_command = 'im-select.exe',
 
             -- Restore the default input method state when the following events are triggered
-            set_default_events = { "VimEnter", "FocusGained", ModeChanged = {"i:*", "c:*", "R:*"} },
+            set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
 
-            -- Save the current input method state when the following ModeChanged patterns are matched
-            save_state_patterns = {"i:n", "R:n"},
+            -- Save the current input method state when the following events are triggered
+            save_state_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
 
             -- Restore the previous used input method state when the following events
             -- are triggered, if you don't want to restore previous used im in Insert mode,
             -- e.g. deprecated `disable_auto_restore = 1`, just let it empty
             -- as `set_previous_events = {}`
-            set_previous_events = { ModeChanged = {"*:i", "*:R"} },
-
-            -- Don't change the input method state when the following ModeChanged patterns are matched
-            exclude_patterns = {"i:c", "c:i"},
+            set_previous_events = { "InsertEnter" },
 
             -- Show notification about how to install executable binary when binary missed
             keep_quiet_on_no_binary = false,

--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -41,9 +41,13 @@ local C = {
     default_method_selected = "1033",
 
     -- Restore the default input method state when the following events are triggered
-    set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+    set_default_events = { "VimEnter", "FocusGained", ModeChanged = {"i:*", "c:*", "R:*"} },
+    -- Save the current using input method state when the following events are triggered
+    save_state_patterns = {["i:n"] = true, ["R:n"] = true},
     -- Restore the previous used input method state when the following events are triggered
-    set_previous_events = { "InsertEnter" },
+    set_previous_events = { ModeChanged = {"*:i", "*:R"} },
+    -- Don't change the input method state when the following events are triggered
+    exclude_patterns = {["i:c"] = true, ["c:i"] = true},
 
     keep_quiet_on_no_binary = false,
 
@@ -95,8 +99,22 @@ local function set_opts(opts)
         C.set_default_events = opts.set_default_events
     end
 
+    if opts.save_state_patterns ~= nil and type(opts.save_state_patterns) == "table" then
+        C.save_state_patterns = {}
+        for _, pattern in pairs(opts.save_state_patterns) do
+            C.save_state_patterns[pattern] = true
+        end
+    end
+
     if opts.set_previous_events ~= nil and type(opts.set_previous_events) == "table" then
         C.set_previous_events = opts.set_previous_events
+    end
+
+    if opts.exclude_patterns ~= nil and type(opts.exclude_patterns) == "table" then
+        C.exclude_patterns = {}
+        for _, pattern in pairs(opts.exclude_patterns) do
+            C.exclude_patterns[pattern] = true
+        end
     end
 
     -- deprecated
@@ -152,16 +170,26 @@ local function change_im_select(cmd, method)
     end
 end
 
-local function restore_default_im()
+local function restore_default_im(args)
+    if C.exclude_patterns[args.match] then
+        return
+    end
+
     local current = get_current_select(C.default_command)
-    vim.api.nvim_set_var("im_select_saved_state", current)
+    if C.save_state_patterns[args.match] then
+        vim.api.nvim_set_var("im_select_saved_state", current)
+    end
 
     if current ~= C.default_method_selected then
         change_im_select(C.default_command, C.default_method_selected)
     end
 end
 
-local function restore_previous_im()
+local function restore_previous_im(args)
+    if C.exclude_patterns[args.match] then
+        return
+    end
+
     local current = get_current_select(C.default_command)
     local saved = vim.g["im_select_saved_state"]
 
@@ -188,6 +216,14 @@ M.setup = function(opts)
     -- set autocmd
     local group_id = vim.api.nvim_create_augroup("im-select", { clear = true })
 
+    if C.set_previous_events.ModeChanged ~= nil then
+        vim.api.nvim_create_autocmd({"ModeChanged"}, {
+            pattern = C.set_previous_events.ModeChanged,
+            callback = restore_previous_im,
+            group = group_id,
+        })
+        C.set_previous_events.ModeChanged = nil
+    end
     if #C.set_previous_events > 0 then
         vim.api.nvim_create_autocmd(C.set_previous_events, {
             callback = restore_previous_im,
@@ -195,6 +231,14 @@ M.setup = function(opts)
         })
     end
 
+    if C.set_default_events.ModeChanged ~= nil then
+        vim.api.nvim_create_autocmd({"ModeChanged"}, {
+            pattern = C.set_default_events.ModeChanged,
+            callback = restore_default_im,
+            group = group_id,
+        })
+        C.set_default_events.ModeChanged = nil
+    end
     if #C.set_default_events > 0 then
         vim.api.nvim_create_autocmd(C.set_default_events, {
             callback = restore_default_im,


### PR DESCRIPTION
I have been using this plugin for a while now, and enjoying the convenience of automatically switching IM, thanks for your work.

However, some specific needs cannot be met:

1. Restoring the default IM on `CmdlineLeave` is valuable, because we may search for some text in the command line. But, in most cases, we just want to execute some commands (e.g. `:w`), and only the default IM will be used. So, we may not expect the default IM to override the previous IM.
2. There is a wired (I'm a Vim newbie) behavior in Neovim: the `CmdlineEnter` (pattern `i:c`) and `CmdlineLeave` (pattern `c:i`) events will be triggered when I type the `Enter` key in the insert mode, which may cause unexpected IM state switching if `CmdlineLeave` is included in `set_default_events`.

Workaround:

The [ModeChanged](https://neovim.io/doc/user/autocmd.html#ModeChanged) event supports the pattern match to identify events precisely:

1. Saving the IM state only on the limited pattern (e.g. `i:n`, `R:n`), which could be configured in `save_state_patterns`.
2. Don't switch the IM state on the specified pattern (e.g. `i:c`, `c:i`), which could be configured in `exclude_patterns`.

---

这个插件非常棒，非常方便，感谢作者的积极维护。

用一段时间后，发现了一些问题：

1. 退出命令行模式时回到英文输入法是很有必要的，因为偶尔搜索文本会切换输入法，但是，大多数时候只是进入命令行模式保存文件，这就不会切换输入法。所以，我不希望退出命令行的时候覆盖上一次保存的输入法。
2. 我的Neovim有一个奇怪的行为（也可是我不懂）：在插入模式下敲回车换行会触发`CmdlineEnter`（`i:c`模式）和`CmdlineLeave`（`c:i`模式）事件，如果在`set_default_events`中配置了`CmdlineLeave`就会自动切换为英文输入法。

解决方案：

[ModeChanged](https://neovim.io/doc/user/autocmd.html#ModeChanged)支持使用模式匹配来精确识别事件：

1. 可以限定几个需要保存输入法的事件模式，其他事件模式都不保存输入法；在`save_state_patterns`里面配置
2. 可以指定一些事件模式不要切换输入法；在`exclude_patterns`里面配置