### PR TITLE
Feature: Add smart switch support. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Follow these steps to configure it:
     dependencies = {"nvim-treesitter/nvim-treesitter"}
     config = function()
         require('im_select').setup({
-            -- Enabling this function will render the `set_previous_events` option ineffective
+            -- Enabling this feature will render the `set_previous_events` option ineffective
             smart_switch = true,
         })
     end,
@@ -223,7 +223,7 @@ Follow these steps to configure it:
 
 After setting up the configuration, run the command `:TSInstall xxx`, replacing "xxx" with the name of your language's Treesitter parser. For example, if you're using JavaScript, run `:TSInstall javascript`.
 
-**Important:** Enabling this function will render the `set_previous_events` option ineffective.
+**Important:** Enabling this feature will render the `set_previous_events` option ineffective.
 
 ## 3. Current Issue
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Options with its default values
 
 ### Smart Switch
 
+**TLDR:** Turn on smart switch will record the last IM you used for comments and strings, turn off smart switch will use the last IM you used in insert mode
+
 This feature is designed to analyze the logical structure of your code using Treesitter. It automatically activates the default IM or the previous IM based on the context. When typing comments or strings, it uses the previous IM. In other cases or when in normal mode, it utilizes the default IM.
 
 To enable the feature that automatically selects the default IM or the previous IM based on context, you need to have **Treesitter installed** and configured for your desired programming language. 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Follow these steps to configure it:
     config = function()
         require('im_select').setup({
             -- Enabling this function will render the `set_previous_events` option ineffective
-            smart_switch = false,
+            smart_switch = true,
         })
     end,
 }

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Options with its default values
             -- as `set_previous_events = {}`
             set_previous_events = { "InsertEnter" },
 
+            -- This option will overwrite `set_previous_events` option. See ###Smart Switch for more details
+            smart_switch = false,
+
             -- Show notification about how to install executable binary when binary missed
             keep_quiet_on_no_binary = false,
 
@@ -196,6 +199,31 @@ Options with its default values
     end,
 }
 ```
+
+### Smart Switch
+
+This feature is designed to analyze the logical structure of your code using Treesitter. It automatically activates the default IM or the previous IM based on the context. When typing comments or strings, it uses the previous IM. In other cases or when in normal mode, it utilizes the default IM.
+
+To enable the feature that automatically selects the default IM or the previous IM based on context, you need to have **Treesitter installed** and configured for your desired programming language. 
+
+Follow these steps to configure it:
+
+```lua
+{
+    "keaising/im-select.nvim",
+    dependencies = {"nvim-treesitter/nvim-treesitter"}
+    config = function()
+        require('im_select').setup({
+            -- Enabling this function will render the `set_previous_events` option ineffective
+            smart_switch = false,
+        })
+    end,
+}
+```
+
+After setting up the configuration, run the command `:TSInstall xxx`, replacing "xxx" with the name of your language's Treesitter parser. For example, if you're using JavaScript, run `:TSInstall javascript`.
+
+**Important:** Enabling this function will render the `set_previous_events` option ineffective.
 
 ## 3. Current Issue
 

--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -177,7 +177,6 @@ local function change_im_select(cmd, method)
 end
 
 local function restore_default_im()
-    vim.notify("Switch to EN")
     local current = get_current_select(C.default_command)
     vim.api.nvim_set_var("im_select_saved_state", current)
 
@@ -187,7 +186,6 @@ local function restore_default_im()
 end
 
 local function restore_default_im_without_save()
-    vim.notify("Switch to EN")
     local current = get_current_select(C.default_command)
 
     if current ~= C.default_method_selected then
@@ -196,7 +194,6 @@ local function restore_default_im_without_save()
 end
 
 local function restore_previous_im()
-    vim.notify("Switch to ZH")
     local current = get_current_select(C.default_command)
     local saved = vim.g["im_select_saved_state"]
 


### PR DESCRIPTION
**The implementation of this feature consists of three parts:**

- When the user switches from normal mode to insert mode, if the user enters a string or comment, the Input Method (IM) will switch to the previous one; otherwise, the default IM will be used.
- When the user switches from insert mode to normal mode, if the user exits a string or comment back to normal mode, the IM will switch back to the default IM, and remember this IM. If the user exits from other positions to normal mode, this IM will not be remembered.
- When the user is in insert mode and there is a cursor movement (typing characters or simply moving the cursor), the character before the cursor will be examined to determine if it is the beginning or end of a string or comment. If it is the beginning, the IM will switch to the previous one; if it is the end, the IM will switch from the previous one to the default IM, and the previous IM will be recorded.


**Unimplemented parts:**

- Distinguishing between IM used for comments and strings. Sometimes, it is desired for strings to use the default IM while comments use the previous IM. However, implementing this feature would essentially overturn the logic of saving IM.
- Handling block comments (feasible but not yet implemented).
- Listening to CursorMovedI events combined with Treesitter for precise detection might introduce some performance issues (even if using asynchronous logic). Listening for specific character inputs and then processing the logic might significantly improve performance (for example, in Lua language, entering comments requires typing --, so listening for the - character might be more efficient than listening to CursorMovedI events).