### PR TITLE
fix: remove `CmdlineLeave` from the event list

### DIFF
--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -43,7 +43,7 @@ local C = {
     default_method_selected = "1033",
 
     -- Restore the default input method state when the following events are triggered
-    set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+    set_default_events = { "VimEnter", "FocusGained", "InsertLeave"},
     -- Restore the previous used input method state when the following events are triggered
     set_previous_events = { "InsertEnter" },
 


### PR DESCRIPTION
The `CmdlineLeave` event is supposed to be paired with the `CmdlineEnter` event, which is missing from the event list. This causes the input method to not be restored when exiting command-line mode.