### PR TITLE
fix!: remove VimEnter and FocusGained from `set_default_events`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Options with its default values
             default_command = "im-select.exe",
 
             -- Restore the default input method state when the following events are triggered
-            set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+            -- "VimEnter" and "FocusGained" were removed for causing problems, add it by your needs
+            set_default_events = { "InsertLeave", "CmdlineLeave" },
 
             -- Restore the previous used input method state when the following events
             -- are triggered, if you don't want to restore previous used im in Insert mode,
@@ -198,4 +199,3 @@ Options with its default values
     end,
 }
 ```
-

--- a/lua/im_select.lua
+++ b/lua/im_select.lua
@@ -43,7 +43,7 @@ local C = {
     default_method_selected = "1033",
 
     -- Restore the default input method state when the following events are triggered
-    set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+    set_default_events = { "InsertLeave", "CmdlineLeave" },
     -- Restore the previous used input method state when the following events are triggered
     set_previous_events = { "InsertEnter" },
 


### PR DESCRIPTION
resolve: https://github.com/keaising/im-select.nvim/issues/36