### PR TITLE
update README.md according to commit 9cfe98d

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Options with its default values
             -- or { "AIMSwitcher.exe", "--imm" } for binary need extra arguments to work.
             -- For Windows/WSL, default: "im-select.exe"
             -- For macOS, default: "macism"
-            -- For Linux, default: "fcitx5-remote" or "fcitx-remote" or "ibus"
+            -- For Linux, default: "fcitx5-remote" or "fcitx-remote" or { "ibus", "engine" }
             default_command = "im-select.exe",
 
             -- Restore the default input method state when the following events are triggered


### PR DESCRIPTION
after commit 9cfe98d, ibus default command should be set like  { "ibus", "engine" }, setting to ibus will cause  set_previous_events fail